### PR TITLE
Handle video compression errors and fallbacks

### DIFF
--- a/src/lib/stores/video.ts
+++ b/src/lib/stores/video.ts
@@ -73,7 +73,7 @@ export function completeTask(taskId: string, result: Partial<ProcessingTask>) {
   processingQueue.update(queue => 
     queue.map(task => 
       task.id === taskId 
-        ? { ...task, ...result, status: 'completed' }
+        ? { ...task, ...result, status: 'completed', progress: 100 }
         : task
     )
   );


### PR DESCRIPTION
Force progress bar to 100% upon task completion to accurately reflect when a video is ready for download.

The progress bar previously stalled at 70% if cloud upload or shortlink generation steps were skipped, even though the video was fully processed and downloadable. This change ensures the UI correctly indicates completion.

---
<a href="https://cursor.com/background-agent?bcId=bc-267e2aff-7224-47e2-b373-341245480d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-267e2aff-7224-47e2-b373-341245480d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

