### PR TITLE
Review and correct processing time calculation

### DIFF
--- a/src/lib/components/ProcessingQueue.svelte
+++ b/src/lib/components/ProcessingQueue.svelte
@@ -100,7 +100,11 @@
           <!-- Processing Time -->
           {#if task.processingTime}
             <div class="mt-3 text-xs text-gray-500">
-              Processing time: {Math.round(task.processingTime / 1000)}s
+              {#if (task.processingTime / 1000) >= 60}
+                Processing time: {Math.floor((task.processingTime / 1000) / 60)}m
+              {:else}
+                Processing time: {Math.round(task.processingTime / 1000)}s
+              {/if}
             </div>
           {/if}
           

--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -150,7 +150,11 @@
               <div class="flex justify-between items-center">
                 <span class="text-sm text-gray-600">Processing Time</span>
                 <span class="text-sm font-medium text-gray-900">
-                  {Math.round(video.processingTime / 1000)}s
+                  {#if (video.processingTime / 1000) >= 60}
+                    {Math.floor((video.processingTime / 1000) / 60)}m
+                  {:else}
+                    {Math.round(video.processingTime / 1000)}s
+                  {/if}
                 </span>
               </div>
             {/if}

--- a/src/lib/services/videoProcessing.ts
+++ b/src/lib/services/videoProcessing.ts
@@ -44,6 +44,7 @@ export class VideoProcessingService {
     
     this.isProcessing = true;
     const taskId = addToQueue(file);
+    const startTimeMs = Date.now();
     
     try {
       // Update status to processing
@@ -127,7 +128,7 @@ export class VideoProcessingService {
       }
       
       // Complete the task
-      const processingTime = Date.now(); // Would be calculated from start time
+      const processingTime = Date.now() - startTimeMs;
       
       // Processing completed successfully
       


### PR DESCRIPTION
Fix processing time calculation and display it in minutes when over 60 seconds to improve accuracy and readability.

The original `processingTime` was incorrectly set to `Date.now()` instead of the elapsed time. This PR corrects the calculation by tracking a `startTimeMs` and calculating the difference. It also formats the display to show minutes (using `Math.floor` to prevent overcounting) for durations 60 seconds or longer.

---
<a href="https://cursor.com/background-agent?bcId=bc-b28c5f97-25f5-4a4c-abbb-40eed0b80f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b28c5f97-25f5-4a4c-abbb-40eed0b80f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

