### PR TITLE
Clean up upload interface and logic

### DIFF
--- a/src/lib/components/VideoUploader.svelte
+++ b/src/lib/components/VideoUploader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import { appConfig, processingQueue } from '$lib/stores/video';
+  import { appConfig } from '$lib/stores/video';
   
   function getStatusColor(status: string): string {
     switch (status) {
@@ -31,7 +31,7 @@
   
   $: maxSize = $appConfig.maxFileSize;
   $: supportedFormats = $appConfig.supportedFormats;
-  $: currentTask = $processingQueue.length > 0 ? $processingQueue[$processingQueue.length - 1] : null;
+  // Single upload mode: no queue UI
   
   function formatFileSize(bytes: number): string {
     if (bytes === 0) return '0 Bytes';
@@ -150,7 +150,7 @@
           <button
             type="button"
             class="btn-secondary"
-            on:click|stopPropagation={() => { clearSelection(); openFileDialog(); }}
+            on:click|stopPropagation={() => { dispatch('cancel'); clearSelection(); openFileDialog(); }}
           >
             Cancel & Choose Another
           </button>
@@ -191,92 +191,6 @@
         </div>
       </div>
     {/if}
-
-    {#if currentTask}
-      <div class="mt-6 border-t pt-6 text-left">
-        <div class="flex items-center justify-between mb-3">
-          <h3 class="text-lg font-semibold text-gray-900">Current Task</h3>
-          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-            {$processingQueue.length} {($processingQueue.length === 1) ? 'task' : 'tasks'}
-          </span>
-        </div>
-        <div class="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors duration-200">
-          <div class="flex items-center justify-between mb-3">
-            <div class="flex items-center space-x-3">
-              <div class="flex-shrink-0">
-                <div class="h-8 w-8 rounded-full flex items-center justify-center {getStatusColor(currentTask.status)}">
-                  <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={getStatusIcon(currentTask.status)} />
-                  </svg>
-                </div>
-              </div>
-              <div>
-                <p class="text-sm font-medium text-gray-900 truncate max-w-xs">{currentTask.file.name}</p>
-                <p class="text-xs text-gray-500">{formatFileSize(currentTask.originalSize)}</p>
-              </div>
-            </div>
-            <div class="flex items-center space-x-2">
-              <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium {getStatusColor(currentTask.status)}">
-                {currentTask.status}
-              </span>
-              {#if currentTask.status === 'completed' && currentTask.compressedSize}
-                <span class="text-xs text-gray-500">
-                  {Math.round((1 - currentTask.compressedSize / currentTask.originalSize) * 100)}% smaller
-                </span>
-              {/if}
-            </div>
-          </div>
-
-          {#if currentTask.status === 'processing' || currentTask.status === 'completed'}
-            <div class="mb-3">
-              <div class="flex justify-between text-xs text-gray-500 mb-1">
-                <span>Progress</span>
-                <span>{Math.round(currentTask.progress)}%</span>
-              </div>
-              <div class="w-full bg-gray-200 rounded-full h-2">
-                <div class="bg-blue-600 h-2 rounded-full transition-all duration-300 ease-out" style="width: {currentTask.progress}%"></div>
-              </div>
-            </div>
-          {/if}
-
-          {#if currentTask.status === 'error' && currentTask.error}
-            <div class="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
-              <p class="text-sm text-red-800">{currentTask.error}</p>
-            </div>
-          {/if}
-
-          {#if currentTask.processingTime}
-            <div class="mt-3 text-xs text-gray-500">
-              {#if (currentTask.processingTime / 1000) >= 60}
-                Processing time: {Math.floor((currentTask.processingTime / 1000) / 60)}m
-              {:else}
-                Processing time: {Math.round(currentTask.processingTime / 1000)}s
-              {/if}
-            </div>
-          {/if}
-
-          {#if currentTask.status === 'completed'}
-            <div class="mt-3 flex space-x-2">
-              {#if currentTask.downloadUrl}
-                <a href={currentTask.downloadUrl} download class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-primary-700 bg-primary-100 hover:bg-primary-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
-                  <svg class="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
-                  Download
-                </a>
-              {/if}
-              {#if currentTask.shareUrl}
-                <button class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500" on:click={() => navigator.clipboard.writeText(currentTask.shareUrl || '')}>
-                  <svg class="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" />
-                  </svg>
-                  Copy Link
-                </button>
-              {/if}
-            </div>
-          {/if}
-        </div>
-      </div>
-    {/if}
+    
   </div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,6 +25,16 @@
     console.log('File selected:', file.name);
   }
   
+  async function handleCancel() {
+    try {
+      await videoProcessingService.cancelProcessing();
+    } catch {}
+    currentVideo.set(null);
+    showPreview = false;
+    showLinkGenerator = false;
+    isProcessing = false;
+  }
+
   async function handleStartProcessing(event: CustomEvent) {
     const { file } = event.detail;
     
@@ -149,6 +159,7 @@
         <VideoUploader 
           on:fileSelected={handleFileSelected}
           on:startProcessing={handleStartProcessing}
+          on:cancel={handleCancel}
         />
       {:else}
         <div class="card text-center">


### PR DESCRIPTION
Remove redundant "Current Task" UI and implement full cancellation for video processing and uploads.

The application is designed for single video uploads, making the "Current Task" counter and display unnecessary. Additionally, the "Cancel & Choose Another" button previously only reset the UI without stopping any ongoing FFmpeg processing or Google Drive uploads, leading to wasted resources and potential background errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-1882e551-4a0d-4af0-847e-4896af3c043c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1882e551-4a0d-4af0-847e-4896af3c043c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

