### PR TITLE
Colocar barra de progreso debajo del botón

### DIFF
--- a/src/lib/components/VideoUploader.svelte
+++ b/src/lib/components/VideoUploader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import { appConfig } from '$lib/stores/video';
+  import { processingQueue } from '$lib/stores/video';
   
   function getStatusColor(status: string): string {
     switch (status) {
@@ -32,6 +33,7 @@
   $: maxSize = $appConfig.maxFileSize;
   $: supportedFormats = $appConfig.supportedFormats;
   // Single upload mode: no queue UI
+  $: latestTask = $processingQueue.length > 0 ? $processingQueue[$processingQueue.length - 1] : null;
   
   function formatFileSize(bytes: number): string {
     if (bytes === 0) return '0 Bytes';
@@ -175,6 +177,21 @@
         </div>
       {/if}
     </div>
+    
+    {#if latestTask && (latestTask.status === 'processing' || latestTask.status === 'pending')}
+      <div class="mt-4">
+        <div class="flex justify-between text-xs text-gray-500 mb-1">
+          <span>Progress</span>
+          <span>{Math.round(latestTask.progress)}%</span>
+        </div>
+        <div class="w-full bg-gray-200 rounded-full h-2">
+          <div 
+            class="bg-blue-600 h-2 rounded-full transition-all duration-300 ease-out"
+            style="width: {latestTask.progress}%"
+          ></div>
+        </div>
+      </div>
+    {/if}
     
     <!-- Error Message -->
     {#if errorMessage}


### PR DESCRIPTION
Re-add the video upload progress bar to display processing status.

This restores previously removed functionality, placing the progress bar below the video upload button to show the progress of the latest task in the processing queue.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0f9c4bc-c83b-4e15-9dac-f7d59bc47f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0f9c4bc-c83b-4e15-9dac-f7d59bc47f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

