### PR TITLE
Update ui with compression percentage and remove message

### DIFF
--- a/src/lib/components/LinkGenerator.svelte
+++ b/src/lib/components/LinkGenerator.svelte
@@ -167,17 +167,5 @@
       {/if}
     </div>
     
-    <!-- Additional Options -->
-    <div class="mt-6 pt-6 border-t border-gray-200">
-      <p class="text-sm text-gray-500 mb-3">More options:</p>
-      <div class="flex space-x-2">
-        <button class="flex-1 btn-secondary text-sm">
-          Process Another Video
-        </button>
-        <button class="flex-1 btn-secondary text-sm">
-          View Processing History
-        </button>
-      </div>
-    </div>
   </div>
 </div>

--- a/src/lib/components/ProcessingQueue.svelte
+++ b/src/lib/components/ProcessingQueue.svelte
@@ -101,9 +101,9 @@
           {#if task.processingTime}
             <div class="mt-3 text-xs text-gray-500">
               {#if (task.processingTime / 1000) >= 60}
-                Processing time: {Math.floor((task.processingTime / 1000) / 60)}m
+                Processing time: {Math.floor((task.processingTime / 1000) / 60)}m{#if task.status === 'completed' && task.compressedSize} · {Math.round((1 - task.compressedSize / task.originalSize) * 100)}% smaller{/if}
               {:else}
-                Processing time: {Math.round(task.processingTime / 1000)}s
+                Processing time: {Math.round(task.processingTime / 1000)}s{#if task.status === 'completed' && task.compressedSize} · {Math.round((1 - task.compressedSize / task.originalSize) * 100)}% smaller{/if}
               {/if}
             </div>
           {/if}

--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -148,12 +148,15 @@
             </div>
             {#if video.processingTime}
               <div class="flex justify-between items-center">
-                <span class="text-sm text-gray-600">Processing Time</span>
+                <span class="text-sm text-gray-600">Processing time:</span>
                 <span class="text-sm font-medium text-gray-900">
                   {#if (video.processingTime / 1000) >= 60}
                     {Math.floor((video.processingTime / 1000) / 60)}m
                   {:else}
                     {Math.round(video.processingTime / 1000)}s
+                  {/if}
+                  {#if video.compressionRatio}
+                    — {Math.round((1 - video.compressionRatio) * 100)}% smaller
                   {/if}
                 </span>
               </div>


### PR DESCRIPTION
Display compression percentage next to processing time, update its label, and remove the 'More options' section from the processing complete UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-b653b4de-a3d3-40c9-909a-0b36657835dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b653b4de-a3d3-40c9-909a-0b36657835dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

