### PR TITLE
Fix link copying to use tiny url

### DIFF
--- a/src/lib/components/LinkGenerator.svelte
+++ b/src/lib/components/LinkGenerator.svelte
@@ -20,8 +20,8 @@
       if (video.shareUrl) {
         shareUrl = video.shareUrl;
       } else if (video.downloadUrl && /^https?:\/\//.test(video.downloadUrl)) {
-        // If there is a real, publicly accessible URL, shorten it via TinyURL
-        const { shortUrl } = await tinyUrlService.shortenUrl(video.downloadUrl, 'compressed-video');
+        // If there is a real, publicly accessible URL, shorten it via TinyURL (no static alias)
+        const { shortUrl } = await tinyUrlService.shortenUrl(video.downloadUrl);
         shareUrl = shortUrl;
         video.shareUrl = shortUrl;
       } else {

--- a/src/lib/components/ProcessingQueue.svelte
+++ b/src/lib/components/ProcessingQueue.svelte
@@ -1,5 +1,22 @@
 <script lang="ts">
   import { processingQueue } from '$lib/stores/video';
+  import { tinyUrlService } from '$lib/utils/tinyurl';
+
+  async function copyShareLink(url: string) {
+    if (!url) return;
+    let toCopy = url;
+    try {
+      const isAlreadyShort = /tinyurl\.com\//i.test(url);
+      if (!isAlreadyShort) {
+        const { shortUrl } = await tinyUrlService.shortenUrl(url);
+        toCopy = shortUrl;
+      }
+    } catch (e) {
+      // Fallback to original URL on any error
+    } finally {
+      await navigator.clipboard.writeText(toCopy);
+    }
+  }
   import { formatFileSize } from '$lib/utils/format';
   
   function getStatusColor(status: string): string {
@@ -126,7 +143,7 @@
               {#if task.shareUrl}
                 <button
                   class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-                  on:click={() => navigator.clipboard.writeText(task.shareUrl || '')}
+                  on:click={() => copyShareLink(task.shareUrl || '')}
                 >
                   <svg class="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" />

--- a/src/lib/services/videoProcessing.ts
+++ b/src/lib/services/videoProcessing.ts
@@ -223,7 +223,8 @@ export class VideoProcessingService {
   
   private async generateShortLink(longUrl: string): Promise<any> {
     try {
-      return await tinyUrlService.shortenUrl(longUrl, 'compressed-video');
+      // Do not use a static alias to avoid collisions
+      return await tinyUrlService.shortenUrl(longUrl);
     } catch (error) {
       console.error('TinyURL link generation failed:', error);
       throw new Error('Failed to generate shortened link. Please try again.');


### PR DESCRIPTION
Integrate TinyURL v2 API and ensure all "copy link" actions use a shortened URL when `VITE_TINYURL_API_KEY` is configured.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fa1f041-5138-4e07-9a52-e7c8d1a183e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5fa1f041-5138-4e07-9a52-e7c8d1a183e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

