### PR TITLE
Fix cancel button marking item as complete

### DIFF
--- a/src/lib/services/videoProcessing.ts
+++ b/src/lib/services/videoProcessing.ts
@@ -1,7 +1,7 @@
 import { videoProcessor } from '$lib/utils/ffmpeg';
 import { googleDriveService } from '$lib/utils/googleDrive';
 import { tinyUrlService } from '$lib/utils/tinyurl';
-import { addToQueue, updateTaskProgress, completeTask, type ProcessingTask } from '$lib/stores/video';
+import { addToQueue, updateTaskProgress, completeTask, failTask, type ProcessingTask } from '$lib/stores/video';
 import { generateId } from '$lib/utils/format';
 import { browser } from '$app/environment';
 import {
@@ -158,10 +158,7 @@ export class VideoProcessingService {
       updateTaskProgress(taskId, 0, 'error');
       
       // Processing failed
-      
-      completeTask(taskId, {
-        error: error instanceof Error ? error.message : 'Unknown error occurred',
-      });
+      failTask(taskId, error instanceof Error ? error.message : 'Unknown error occurred');
       throw error;
     } finally {
       this.isProcessing = false;

--- a/src/lib/stores/video.ts
+++ b/src/lib/stores/video.ts
@@ -79,6 +79,16 @@ export function completeTask(taskId: string, result: Partial<ProcessingTask>) {
   );
 }
 
+export function failTask(taskId: string, errorMessage?: string) {
+  processingQueue.update(queue => 
+    queue.map(task => 
+      task.id === taskId 
+        ? { ...task, status: 'error', ...(errorMessage ? { error: errorMessage } : {}) }
+        : task
+    )
+  );
+}
+
 export function removeTask(taskId: string) {
   processingQueue.update(queue => queue.filter(task => task.id !== taskId));
 }


### PR DESCRIPTION
Prevent cancellations from marking tasks as completed by introducing a `failTask` function.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4af5fdb-fa2b-4b90-959d-2d2d708c78a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4af5fdb-fa2b-4b90-959d-2d2d708c78a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

