### PR TITLE
Add time label and compression percentage

### DIFF
--- a/src/lib/components/VideoUploader.svelte
+++ b/src/lib/components/VideoUploader.svelte
@@ -250,9 +250,14 @@
             </div>
             <span class="text-sm font-medium text-green-700">Completado</span>
           </div>
-          {#if latestTask.processingTime}
-            <span class="text-xs text-green-700">{formatDurationMs(latestTask.processingTime)}</span>
-          {/if}
+          <div class="text-xs text-green-700 flex items-center space-x-2">
+            {#if latestTask.processingTime}
+              <span><span class="font-medium">Processing time:</span> {formatDurationMs(latestTask.processingTime)}</span>
+            {/if}
+            {#if latestTask.compressedSize}
+              <span>· {Math.round((1 - latestTask.compressedSize / latestTask.originalSize) * 100)}% smaller</span>
+            {/if}
+          </div>
         </div>
         
         <!-- Action buttons -->


### PR DESCRIPTION
Add "Processing time" label and "% smaller" display to the video upload completion box to provide more descriptive feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ce19676-f2d3-4460-95e4-ad6c31cb0e6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ce19676-f2d3-4460-95e4-ad6c31cb0e6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

