### PR TITLE
Show preview after video conversion

### DIFF
--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -43,7 +43,9 @@
           preload="metadata"
           on:loadedmetadata={onVideoLoaded}
         >
-          {#if video.originalFile}
+          {#if video.status === 'completed' && video.downloadUrl}
+            <source src={video.downloadUrl} />
+          {:else if video.originalFile}
             <source src={URL.createObjectURL(video.originalFile)} type={video.originalFile.type} />
           {/if}
           <track kind="captions" src="" label="No captions available" srclang="en" default />
@@ -134,10 +136,10 @@
               <span class="text-sm text-gray-600">Original Size</span>
               <span class="text-sm font-medium text-gray-900">{formatFileSize(video.size)}</span>
             </div>
-            {#if video.processedFile}
+            {#if video.compressedSize}
               <div class="flex justify-between items-center">
                 <span class="text-sm text-gray-600">Compressed Size</span>
-                <span class="text-sm font-medium text-gray-900">{formatFileSize(video.processedFile.size)}</span>
+                <span class="text-sm font-medium text-gray-900">{formatFileSize(video.compressedSize)}</span>
               </div>
             {/if}
             <div class="flex justify-between items-center">

--- a/src/lib/stores/video.ts
+++ b/src/lib/stores/video.ts
@@ -25,6 +25,7 @@ export interface VideoFile {
   error?: string;
   originalFile?: File;
   processedFile?: File;
+  compressedSize?: number;
   downloadUrl?: string;
   shareUrl?: string;
   processingTime?: number;
@@ -55,13 +56,13 @@ export function addToQueue(file: File): string {
     originalSize: file.size
   };
   
-  processingQueue.update(queue => [...queue, newTask]);
+  processingQueue.update((queue: ProcessingTask[]) => [...queue, newTask]);
   return taskId;
 }
 
 export function updateTaskProgress(taskId: string, progress: number, status?: ProcessingTask['status']) {
-  processingQueue.update(queue => 
-    queue.map(task => 
+  processingQueue.update((queue: ProcessingTask[]) => 
+    queue.map((task: ProcessingTask) => 
       task.id === taskId 
         ? { ...task, progress, ...(status && { status }) }
         : task
@@ -70,8 +71,8 @@ export function updateTaskProgress(taskId: string, progress: number, status?: Pr
 }
 
 export function completeTask(taskId: string, result: Partial<ProcessingTask>) {
-  processingQueue.update(queue => 
-    queue.map(task => 
+  processingQueue.update((queue: ProcessingTask[]) => 
+    queue.map((task: ProcessingTask) => 
       task.id === taskId 
         ? { ...task, ...result, status: 'completed', progress: 100 }
         : task
@@ -80,8 +81,8 @@ export function completeTask(taskId: string, result: Partial<ProcessingTask>) {
 }
 
 export function failTask(taskId: string, errorMessage?: string) {
-  processingQueue.update(queue => 
-    queue.map(task => 
+  processingQueue.update((queue: ProcessingTask[]) => 
+    queue.map((task: ProcessingTask) => 
       task.id === taskId 
         ? { ...task, status: 'error', ...(errorMessage ? { error: errorMessage } : {}) }
         : task
@@ -90,7 +91,7 @@ export function failTask(taskId: string, errorMessage?: string) {
 }
 
 export function removeTask(taskId: string) {
-  processingQueue.update(queue => queue.filter(task => task.id !== taskId));
+  processingQueue.update((queue: ProcessingTask[]) => queue.filter((task: ProcessingTask) => task.id !== taskId));
 }
 
 export function clearQueue() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -60,13 +60,14 @@
       };
       
       currentVideo.set(video);
-      showPreview = true;
+      // No mostramos el preview hasta finalizar
+      showPreview = false;
       
       // Start real video processing
       console.log('Starting video processing...');
       console.log('Note: First-time processing may take longer as FFmpeg loads...');
       
-      await videoProcessingService.processVideo(file, {
+      const task = await videoProcessingService.processVideo(file, {
         quality: 0.8,
         enableGoogleDrive: true,
         enableTinyUrl: true,
@@ -74,7 +75,18 @@
       });
       
       // Update video status
-      currentVideo.update(v => v ? { ...v, status: 'completed', progress: 100 } : null);
+      currentVideo.update(v => v ? { 
+        ...v, 
+        status: 'completed', 
+        progress: 100,
+        processedFile: undefined,
+        downloadUrl: task.downloadUrl,
+        shareUrl: task.shareUrl,
+        processingTime: task.processingTime,
+        compressedSize: task.compressedSize,
+        compressionRatio: task.compressedSize ? (task.compressedSize / v.size) : undefined
+      } : null);
+      showPreview = true;
       
     } catch (error) {
       console.error('Video processing failed:', error);


### PR DESCRIPTION
Show video preview only after compression and conversion are complete, using the final compressed video and displaying its size.

The user requested to defer the preview until the video is fully processed (compressed and converted) to ensure they see the final output. This change updates the UI logic to reflect the processing state and uses the `downloadUrl` for the completed video.

---
<a href="https://cursor.com/background-agent?bcId=bc-b784357b-e897-49c9-a8bf-b87902635089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b784357b-e897-49c9-a8bf-b87902635089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

